### PR TITLE
fix missing gradle properties

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,2 @@
+sonatype_snapshotURL=https://oss.sonatype.org/content/repositories/snapshots
+sonatype_stageingURL=https://oss.sonatype.org/service/local/staging/deploy/maven2/


### PR DESCRIPTION
those variables are important for the maintainer, but not needed for the
day-to-day building the examples. Provided that they exist we can get read-only
access, while maintainer can provide the credentials at
`~/.gradle/gradle.properties`. So build doesn't fail for a clean git clone :)