### PR TITLE
Wires - Docking bug fixing.

### DIFF
--- a/src/main/java/com/ait/lienzo/ks/client/views/components/WiresDockingViewComponent.java
+++ b/src/main/java/com/ait/lienzo/ks/client/views/components/WiresDockingViewComponent.java
@@ -46,13 +46,20 @@ public class WiresDockingViewComponent extends AbstractToolBarViewComponent
 
             @Override
             public boolean acceptDocking(WiresContainer parent, WiresShape child) {
-                return parent.getContainer().getUserData().equals("parent")
-                        && child.getContainer().getUserData().equals( "dock" );
+                final String pd = getUserData(parent);
+                final String cd = getUserData(child);
+                return "parent".equals(pd) && "dock".equals(cd);
             }
 
             @Override
             public int getHotspotSize() {
                 return IDockingAcceptor.HOTSPOT_SIZE;
+            }
+
+            private String getUserData(WiresContainer shape) {
+                return (null != shape && null != shape.getContainer() &&
+                        null != shape.getContainer().getUserData()) ?
+                        shape.getContainer().getUserData().toString() : null;
             }
 
         });


### PR DESCRIPTION
Hey @SprocketNYC ,
This is just a fix for an NPE in the docking screens for KS. The KS is now using an old release of the lienzo-core, so no worries again for merging this, as it needs to  be upgraded to latest core (285-SNAPSHOT).
Thanks in advance!
Roger